### PR TITLE
Aggregated: rack and rack-session security patches (CVE-2025-46727, CVE-2025-46336)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,8 +80,9 @@ GEM
     psych (5.1.2)
       stringio
     racc (1.8.1)
-    rack (3.1.7)
-    rack-session (2.0.0)
+    rack (3.1.14)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     psych (5.1.2)
       stringio
     racc (1.8.1)
-    rack (3.1.7)
+    rack (3.1.14)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)


### PR DESCRIPTION
## Summary

Aggregates two Dependabot security PRs (#3, #4) into a single reviewable changeset.

- **rack 3.1.7 → 3.1.14** (#3): Fixes five CVEs accumulated over 7 patch releases, including `CVE-2025-46727` (unbounded parameter parsing → memory exhaustion in `Rack::QueryParser`), `CVE-2025-27610` (local file inclusion in `Rack::Static`), and two log injection vulnerabilities in `Rack::CommonLogger` and `Rack::Sendfile`.
- **rack-session 2.0.0 → 2.1.1** (#4): Fixes `CVE-2025-46336` — `Rack::Session::Pool` could recreate deleted sessions, allowing session fixation after explicit logout.

### Why security patches belong together

These two patches touch related middleware. Reviewing them together makes it easier to see the full picture of the session/request stack's security posture in one diff. Each patch is a pure version bump with no API changes — the only file changed is `Gemfile.lock`.

**Rule of thumb:** dependency security patches should be merged promptly — the CVE details are public once the advisory is published, giving attackers a race window between the advisory and your deploy. Treat them like hotfixes.


---
_Generated by [Claude Code](https://claude.ai/code/session_015FwgW7ca2b4mEq8dgocGJh)_